### PR TITLE
`prepublish`を`prepublishOnly`に置き換え

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "tslint src/**/*.ts __tests__/**/*.ts",
     "lint:fix": "npm run lint -- --fix",
     "precommit": "lint-staged",
-    "prepublish": "npm run lint && npm run test && npm run build",
+    "prepublishOnly": "npm run lint && npm run test && npm run build",
     "release": "release-it --no-npm.publish",
     "test": "jest --coverage"
   },


### PR DESCRIPTION
npm@5 で `prepublish` が deprecated になったらしいので、代替である `prepublishOnly` に変更した。
https://github.com/npm/npm/issues/10074

誰か一人 approve もらえればマージします。
