### PR TITLE
@types/node をインストールする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -982,9 +982,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-      "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==",
+      "version": "12.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.3.tgz",
+      "integrity": "sha512-opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@maboroshi/prettier-config": "^1.0.0",
     "@maboroshi/tslint-config": "^1.0.1",
     "@types/jest": "^24.0.13",
+    "@types/node": "^12.12.3",
     "husky": "^3.0.0",
     "jest": "^24.8.0",
     "lint-staged": "^9.1.0",


### PR DESCRIPTION
#100 

tsc が吐く `Duplicate identifier 'IteratorResult'.` のエラーを解消するために @types/node を devDependencies に明示的にインストールしてみます。
開発環境としては  node `12.13.0` を前提としているので、同じメジャーバージョンの型定義を指定しておいても良いのではないかと考えました。
tsc で `--skipLibCheck` するのとどっちが良いのかは正直分からん。
いかがでしょうか。